### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/inhtam/inh/security/code-scanning/1](https://github.com/inhtam/inh/security/code-scanning/1)

To fix this problem, we should add an explicit `permissions` block somewhere within the workflow file to restrict the permissions granted to the GITHUB_TOKEN; the least permissive option that enables the workflow functionality should be chosen. Since the jobs simply check out code, run tests, and publish to npm, they only need read access to repository contents. Thus, add `permissions: contents: read` at the workflow root (top-level, alongside `name:` and `on:`), so it applies to all jobs unless further expanded for specific job needs; if in the future a job is added that needs e.g. `issues: write`, it can be granted at job-level. No additional imports or code definitions are required; just insert the relevant block as described above.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
